### PR TITLE
Support for Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "illuminate/view": "4.0.x"
+        "illuminate/view": "4.x"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Updated dependency on illuminate/view so that this packaged can be installed with "laravel/framework": "4.1.*@dev"

A few other packages have updated their composer.json like this https://github.com/Kindari/laravel-markdown/blob/master/composer.json
