### PR TITLE
Config to enable/disable minification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ Test Page | w/o Gzip | w/ Gzip | w/ Gzip + Laravel HTML Minify
 2. Run `composer update`
 3. Add `Fitztrev\LaravelHtmlMinify\LaravelHtmlMinifyServiceProvider` to the list of providers in **app/config/app.php**.
 4. **Important:** You won't see any changes until you edit your `*.blade.php` template files. Once Laravel detects a change, it will recompile them, which is when this package will go to work. To force all views to be recompiled, just run this command: `find . -name "*.blade.php" -exec touch {} \;`
+
+## Config
+
+Optionally, you can choose to customize how the minifier functions for different environments. Publish the configuration file and edit accordingly.
+
+    $ php artisan config:publish fitztrev/laravel-html-minify
+
+### Options
+
+- **`enabled`** - *boolean*, default **true**

--- a/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
+++ b/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
@@ -4,12 +4,18 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class LaravelHtmlMinifyCompiler extends BladeCompiler
 {
-    public function __construct($files, $cachePath)
+    private $config;
+
+    public function __construct($config, $files, $cachePath)
     {
         parent::__construct($files, $cachePath);
 
+        $this->config = $config;
+
         // Add Minify to the list of compilers
-        $this->compilers[] = 'Minify';
+        if ($this->config['enabled'] === true) {
+            $this->compilers[] = 'Minify';
+        }
     }
 
     /**

--- a/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyServiceProvider.php
+++ b/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyServiceProvider.php
@@ -30,12 +30,17 @@ class LaravelHtmlMinifyServiceProvider extends ServiceProvider
     public function register()
     {
         $app = $this->app;
-        $app->view->getEngineResolver()->register('blade.php', function () use ($app) {
-            $cachePath = $app['path'].'/storage/views';
-            $compiler  = new LaravelHtmlMinifyCompiler($app['files'], $cachePath);
+        $app->view->getEngineResolver()->register('blade.php',
+            function () use ($app) {
+                $cachePath = $app['path'].'/storage/views';
+                $compiler  = new LaravelHtmlMinifyCompiler(
+                    $app->make('config')->get('laravel-html-minify::config'),
+                    $app['files'],
+                    $cachePath
+                );
 
-            return new CompilerEngine($compiler);
-        });
+                return new CompilerEngine($compiler);
+            });
         $app->view->addExtension('blade.php', 'blade.php');
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,6 @@
+<?php return array(
+
+    // Turn on/off minification
+    'enabled' => true,
+
+);

--- a/tests/BaseMinifyTest.php
+++ b/tests/BaseMinifyTest.php
@@ -3,11 +3,21 @@
 use Mockery as m;
 use Fitztrev\LaravelHtmlMinify\LaravelHtmlMinifyCompiler;
 
-class MinifyTest extends PHPUnit_Framework_TestCase
+abstract class BaseMinifyTester extends PHPUnit_Framework_TestCase
 {
-    public function __construct()
+    private $config;
+
+    public function setUp()
     {
-        $this->compiler = new LaravelHtmlMinifyCompiler(m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $this->config = array(
+            'enabled' => true,
+        );
+
+        $this->compiler = new LaravelHtmlMinifyCompiler(
+            $this->config,
+            m::mock('Illuminate\Filesystem\Filesystem'),
+            __DIR__
+        );
     }
 
     /* *** */
@@ -27,7 +37,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <p>hello</p> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testKeepConditionalComments()
@@ -44,7 +59,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <!--[if IE 6]> <p>hello, IE6 user</p> <![endif]--> <!--[if IE 8]><p>hello, IE8 user</p><![endif]--> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     /* *** */
@@ -129,7 +149,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <head> <script type="text/javascript" src="script.js"></script> </head> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testSingleExternalScriptTagWithCacheBuster()
@@ -142,7 +167,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <head> <script type="text/javascript" src="script.<?php echo filemtime("script.js"); ?>.js"></script> </head> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testMultipleExternalScriptTag()
@@ -156,7 +186,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <head> <script type="text/javascript" src="script1.js"></script> <script type="text/javascript" src="script2.js"></script> </head> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testExternalAndEmbeddedScriptTag()
@@ -274,7 +309,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <form> <input type="submit" value="Submit" /> </form> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testValueWithoutMultipleSpacesSingleWordSingleQuotes()
@@ -289,7 +329,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <form> <input type="submit" value=\'Submit\' /> </form> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testValueWithoutMultipleSpacesMultipleWords()
@@ -304,7 +349,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <form> <input type="submit" value="Add Document" /> </form> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testValueWithMultipleSpaces()
@@ -361,7 +411,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <p>hello</p> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testMultipleSpaces()
@@ -374,7 +429,12 @@ class MinifyTest extends PHPUnit_Framework_TestCase
         $expected = '<html> <body> <p>hello with random spaces</p> </body> </html>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
     public function testPHPTags()
@@ -385,7 +445,32 @@ echo "hello";
         $expected = '<?php echo "hello";?>';
 
         $result = $this->compiler->compileString($string);
-        $this->assertEquals( $expected, $result );
+
+        if ($this->config['enabled']) {
+            $this->assertEquals( $expected, $result );
+        } else {
+            $this->assertEquals( $string, $result );
+        }
     }
 
+}
+
+class EnabledTester extends BaseMinifyTester
+{
+}
+
+class DisabledTester extends BaseMinifyTester
+{
+    public function setUp()
+    {
+        $this->config = array(
+            'enabled' => false,
+        );
+
+        $this->compiler = new LaravelHtmlMinifyCompiler(
+            $this->config,
+            m::mock('Illuminate\Filesystem\Filesystem'),
+            __DIR__
+        );
+    }
 }


### PR DESCRIPTION
Package config that will allow minification to be turned on/off (see #6). It works but I just need to update the tests and docs accordingly.
- [x] Publish package config file

``` bash
$ php artisan config:publish fitztrev/laravel-html-minify
```
- [x] Read config setting and determine whether or not to minify
- [x] Update tests to check output when `enabled` is **true**
- [x] Update tests to check output when `enabled` is **false**
- [x] Update README with instructions for `config:publish`
