### PR TITLE
added configuration settings for open/close content/escaped content tags

### DIFF
--- a/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
+++ b/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
@@ -16,6 +16,18 @@ class LaravelHtmlMinifyCompiler extends BladeCompiler
         if ($this->_config['enabled'] === true) {
             $this->compilers[] = 'Minify';
         }
+
+        // Set Blade contentTags and escapedContentTags
+        $this->setContentTags(
+            $this->_config['blade']['contentTags'][0],
+            $this->_config['blade']['contentTags'][1]
+        );
+
+        $this->setEscapedContentTags(
+            $this->_config['blade']['escapedContentTags'][0],
+            $this->_config['blade']['escapedContentTags'][1]
+        );
+
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,5 +2,9 @@
 
     // Turn on/off minification
     'enabled' => true,
+    'blade' => array(
+        'contentTags' => array('{{', '}}'),
+        'escapedContentTags' => array('{{{', '}}}')
+    )
 
 );

--- a/tests/BaseMinifyTest.php
+++ b/tests/BaseMinifyTest.php
@@ -473,6 +473,10 @@ class EnabledTester extends BaseMinifyTester
     {
         $this->config = array(
             'enabled' => true,
+            'blade' => array(
+                'contentTags' => array('{{', '}}'),
+                'escapedContentTags' => array('{{{', '}}}')
+            )
         );
     }
 
@@ -488,6 +492,10 @@ class DisabledTester extends BaseMinifyTester
     {
         $this->config = array(
             'enabled' => false,
+            'blade' => array(
+                'contentTags' => array('{{', '}}'),
+                'escapedContentTags' => array('{{{', '}}}')
+            )
         );
     }
 


### PR DESCRIPTION
I was unable to find anyway to be able to read out the `contentTag` and `escapedContentTag` properties of the `BladeCompiler` class. There are no getters, only setters. So here is a solution where I have added extra configuration parameters to allow for custom blade tags

Updated `config.php`

```
<?php return array(

    // Turn on/off minification
    'enabled' => true,
    'blade'   => array(
        'contentTags'        => array('{{', '}}'),
        'escapedContentTags' => array('{{{', '}}}')
    )

);
```

Addresses the following issues:
fitztrev/laravel-html-minify#9 and fitztrev/laravel-html-minify#15
