### PR TITLE
Update LaravelHtmlMinifyCompiler.php

### DIFF
--- a/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
+++ b/src/Fitztrev/LaravelHtmlMinify/LaravelHtmlMinifyCompiler.php
@@ -72,6 +72,7 @@ class LaravelHtmlMinifyCompiler extends BladeCompiler
                 "/\n/"                      => '',
                 "/\t/"                      => ' ',
                 "/ +/"                      => ' ',
+                '/\[(google[\w:\s]+)\]/'    => '<!--$1-->'
             );
 
             return preg_replace(


### PR DESCRIPTION
Sometimes we need use some google expressions like <!--googleoff: index-->.  I  tried add to  exception this case, but I don't know how to do this. That's why I changed compileMinify function
